### PR TITLE
Fix `cb` sometimes not being a function

### DIFF
--- a/src/angular-bluebird-promises.js
+++ b/src/angular-bluebird-promises.js
@@ -23,7 +23,7 @@ $qBluebird.defer = function() {
   });
   deferred.promise.progressCallbacks = [];
   deferred.notify = function(progressValue) {
-    deferred.promise.progressCallbacks.forEach(cb => cb(progressValue));
+    deferred.promise.progressCallbacks.forEach(cb => typeof cb === 'function' && cb(progressValue));
   };
   return deferred;
 };


### PR DESCRIPTION
This happens when using a deferred and not providing a progress callback.

However since the `progressCallbacks` property is mutable from the outside, this changes the invocation instead of the appending.